### PR TITLE
chore: remove PF ownership on Github actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,14 +11,11 @@
 # Jenkinsfile has access to secrets and grants access to AWS resources
 /Jenkinsfile @ContentSquare/Platform
 
-# Makefile are called by Jenkinsfile and inherit their access
-Makefile* @ContentSquare/Platform
-
 # Dockerfile describes the images that will be put into production
 Dockerfile* @ContentSquare/Platform
 
-# .github controls CODEOWNERS and Github actions (not used at the moment)
-/.github/ @ContentSquare/Platform
+# .github controls CODEOWNERS
+/.github/CODEOWNERS @ContentSquare/Platform
 
 # .infra describes the production resources
 .infra/ @ContentSquare/Platform


### PR DESCRIPTION
# Description

Now that GitHub actions have proper secret management/limited aws access/Actions allowlist PF can stop reviewing them.
This PR also aligns the PF block in CODEOWNER in order to make future modification easier

# Context

This PR is an automated one part of a mass PR that can be found here : https://github.com/pulls?q=is%3Aopen+is%3Apr+author%3Ajb-abbadie+archived%3Afalse+label%3Acodeowner-gha

# Jira
PF-8248
