### PR TITLE
Chore: Unit team enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @ContentSquare/tag
+* @ContentSquare/tag-core @ContentSquare/tag-functions
 
 # ==============
 # Platform stuff
@@ -9,7 +9,7 @@
 /.github/CODEOWNERS @ContentSquare/devx
 
 # Protect .github/agents folder for GitHub Copilot agents
-/.github/agents/ @ContentSquare/tag
+/.github/agents/ @ContentSquare/tag-core @ContentSquare/tag-functions
 
 # ==============
 # Platform stuff


### PR DESCRIPTION

### Context
- [Slack communication](https://contentsquare.slack.com/archives/C055MDGK5FZ/p1771514124916899?thread_ts=1770652098.701229&cid=C055MDGK5FZ)
- [Documentation](https://next-docs.csquad.io/platform/github/teams/)


### What was done
Replace legacy github teams by terraform managed team.

This change shouldn't be a surprise. If it is, please contact [#talkto-pf-devx](https://contentsquare.slack.com/archives/C06FTQD5RTJ)


> [!IMPORTANT]  
> Merge this PR autonomously after reviewing if all check have succeded

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>